### PR TITLE
Feature/popup with link btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New `popupWithLink` prop.
+- New `popupWithLink` variation.
 ## [2.59.0] - 2021-04-22
 ### Added
 - I18n Jp and No.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - New `popupWithLink` prop.
 ## [2.59.0] - 2021-04-22

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ The VTEX Minicart is a block that displays a summary list of all items added by 
 | `customPixelEventId` | `string`   | Store event ID responsible for triggering the `minicart.v2` to automatically open itself on the interface. | `undefined`    |
 | `customPixelEventName` | `string`   | Store event name responsible for triggering the `minicart.v2` to automatically open itself on the interface. Some examples are: `'addToCart'` and `'removeFromCart'`. Notice that using this prop will make the `minicart.v2` open in **every** event with the specified name if no `customPixelEventId` is specified. | `undefined`    |
 | `classes`         | `CustomCSSClasses` | Used to override default CSS handles. To better understand how this prop works, we recommend reading about it [here](https://github.com/vtex-apps/css-handles#usecustomclasses). Note that this is only useful if you're importing this block as a React component.                                      | `undefined`           |
-| `popupWithLink`          | `boolean`  | If the minicart is in `popup` variation and is `hover` mode, this prop transforms the minicart button in a link to the checkout when clicked  | `false`        |
+| `popupWithLink`          | `boolean`  | If the minicart is in `popupWithLink` variation and is `hover` mode, it transforms the minicart button in a link to the checkout when clicked  | `false`        |
 
 ### Advanced Configuration
 

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -41,7 +41,6 @@ interface MinicartProps {
   customPixelEventId?: string
   customPixelEventName?: PixelEventTypes.EventName
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
-  popupWithLink?: boolean
 }
 
 const Minicart: FC<MinicartProps> = ({
@@ -55,14 +54,13 @@ const Minicart: FC<MinicartProps> = ({
   drawerSlideDirection = 'rightToLeft',
   customPixelEventId,
   customPixelEventName,
-  classes,
-  popupWithLink = false
+  classes
 }) => {
   const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
 
   const { variation } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
-
+  
   if (variation === 'link') {
     return (
       <aside
@@ -75,7 +73,7 @@ const Minicart: FC<MinicartProps> = ({
               withModifiers={withModifiers}
             >
               <MinicartIconButton
-                popupWithLink={popupWithLink}
+                variation={variation}
                 Icon={MinicartIcon}
                 itemCountMode={itemCountMode}
                 quantityDisplay={quantityDisplay}
@@ -86,7 +84,7 @@ const Minicart: FC<MinicartProps> = ({
       </aside>
     )
   }
-
+  
   return (
     <aside
       className={`${handles.minicartWrapperContainer} relative fr flex items-center`}
@@ -109,9 +107,19 @@ const Minicart: FC<MinicartProps> = ({
             >
               {children}
             </DrawerMode>
+          ) : variation === 'popupWithLink' ? (
+            <PopupMode
+              Icon={MinicartIcon}
+              itemCountMode={itemCountMode}
+              quantityDisplay={quantityDisplay}
+              customPixelEventId={customPixelEventId}
+              customPixelEventName={customPixelEventName}
+              variation={variation}
+            >
+              {children}
+            </PopupMode>
           ) : (
             <PopupMode
-              popupWithLink={popupWithLink}
               Icon={MinicartIcon}
               itemCountMode={itemCountMode}
               quantityDisplay={quantityDisplay}

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -62,10 +62,11 @@ const MinicartContextProvider: FC<Props> = ({
   children,
 }) => {
   const { isMobile } = useDevice()
+  const isPopup = variation === 'popup' || variation === 'popupWithLink'
 
   // This prevents a popup minicart from being used on a mobile device
   const resolvedVariation =
-    variation === 'popup' && (isMobile || (window && window.innerWidth <= 480))
+    isPopup && (isMobile || (window && window.innerWidth <= 480))
       ? 'drawer'
       : variation
 
@@ -75,7 +76,7 @@ const MinicartContextProvider: FC<Props> = ({
     hasBeenOpened: false,
     openOnHoverProp,
     openBehavior:
-      resolvedVariation === 'popup' && openOnHoverProp ? 'hover' : 'click',
+      (resolvedVariation === 'popup' || resolvedVariation === 'popupWithLink') && openOnHoverProp ? 'hover' : 'click',
   })
 
   return (

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -17,7 +17,7 @@ interface Props {
   Icon: React.ComponentType
   quantityDisplay: QuantityDisplayType
   itemCountMode: MinicartTotalItemsType
-  popupWithLink?: boolean
+  variation?: string
 }
 
 const countCartItems = (
@@ -56,7 +56,7 @@ const countCartItems = (
 }
 
 const MinicartIconButton: React.FC<Props> = props => {
-  const { Icon, itemCountMode, quantityDisplay, popupWithLink } = props
+  const { Icon, itemCountMode, quantityDisplay, variation } = props  
   const { orderForm, loading }: OrderFormContext = useOrderForm()
   const { handles } = useMinicartCssHandles()
   const { open, openBehavior, openOnHoverProp } = useMinicartState()
@@ -67,7 +67,7 @@ const MinicartIconButton: React.FC<Props> = props => {
   const goToCheckout = useCheckout()  
   const handleClick = () => {
     if (openOnHoverProp) {
-      if(popupWithLink){
+      if(variation === 'popupWithLink'){
         goToCheckout(checkoutUrl)
       }
       if (openBehavior === 'hover') {

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -20,7 +20,7 @@ interface Props {
   itemCountMode: MinicartTotalItemsType
   customPixelEventId?: string
   customPixelEventName?: PixelEventTypes.EventName
-  popupWithLink?: boolean
+  variation?: string
 }
 
 const PopupMode: FC<Props> = props => {
@@ -31,7 +31,7 @@ const PopupMode: FC<Props> = props => {
     itemCountMode,
     customPixelEventId,
     customPixelEventName,
-    popupWithLink
+    variation
   } = props
 
   const {
@@ -40,7 +40,7 @@ const PopupMode: FC<Props> = props => {
     hasBeenOpened,
     openOnHoverProp,
   } = useMinicartState()
-
+  
   const dispatch = useMinicartDispatch()
   const { handles } = useMinicartCssHandles()
 
@@ -67,7 +67,7 @@ const PopupMode: FC<Props> = props => {
   return (
     <div onMouseLeave={openBehavior === 'hover' ? handleMouseLeave : undefined}>
       <MinicartIconButton
-        popupWithLink={popupWithLink}
+        variation={variation}
         Icon={Icon}
         itemCountMode={itemCountMode}
         quantityDisplay={quantityDisplay}

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -12,4 +12,4 @@ type SlideDirectionType =
   | 'rightToLeft'
   | 'leftToRight'
 
-type MinicartVariationType = 'popup' | 'drawer' | 'link'
+type MinicartVariationType = 'popup' | 'drawer' | 'link' | 'popupWithLink'


### PR DESCRIPTION
#### What problem is this solving?

The client has the minicart set as "popup" and "hover", but there was a need for it to act as a link for the checkout when clicked.

#### How to test it?

Add a product to the cart, check the minicart, when clicking on the minicart icon the user must be redirected to checkout

[Workspace](https://minicartpopup--tokstokio.myvtex.com/)

Screenshots or example usage:

[Video](https://nimbusweb.me/s/share/5685878/au0vp4b0z79s6xp2lhvp)

